### PR TITLE
Let conda and pipenv be friends for geospatial packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN cd /tmp && \
     $CONDA_DIR/bin/conda config --system --prepend channels conda-forge && \
     $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
     $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
+    $CONDA_DIR/bin/conda config --system --set pip_interop_enabled true && \
     $CONDA_DIR/bin/conda clean --all --quiet --yes && \
     $CONDA_DIR/bin/conda init --verbose
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,8 @@ RUN conda env update -n base -f environment.yml && \
 COPY Pipfile* ${HOME}/
 RUN conda activate base && \
     export LD_LIBRARY_PATH=${CONDA_PREFIX}/lib && \
-    pipenv install --python ${CONDA_PREFIX}/bin/python --dev --deploy && \
+    pipenv --python ${CONDA_PREFIX}/bin/python --site-packages && \
+    pipenv install --dev --deploy && \
     rm --recursive ${HOME}/.cache/pip* && \
     pipenv graph
 

--- a/Pipfile
+++ b/Pipfile
@@ -6,12 +6,17 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
+cartopy = {editable = true,git = "https://github.com/SciTools/cartopy.git",ref = "v0.17.0-174-g0e5eef8"}
+cython = "==0.29.13"
+geoviews = "==1.6.5"
 h5netcdf = "==0.7.4"
 intake = "==0.5.3"
 intake-xarray = "==0.3.1"
 jupyterlab = "==1.2.0a0"
 lxml = "==4.4.1"
 pydap = "==3.2.2"
+pyepsg = "==0.4.0"
+pyproj = "==2.4.0"
 xrviz = "==0.1.3"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8a95a19f05c92ecec040536552b6a640c49703b65f3b144bca53119b23844ce9"
+            "sha256": "f9775a4d16656484dc9919f0f81389655f4cc8cfa8da6eb0c9004fe7802f6778"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -64,6 +64,11 @@
             ],
             "version": "==1.3.4"
         },
+        "cartopy": {
+            "editable": true,
+            "git": "https://github.com/SciTools/cartopy.git",
+            "ref": "0e5eef86afe3502bfc41b84f71ba2bf48e2812bd"
+        },
         "certifi": {
             "hashes": [
                 "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
@@ -73,34 +78,45 @@
         },
         "cftime": {
             "hashes": [
-                "sha256:01e878ddca9bf049eaa70805f250942005f63f784a47838b7c48f245b7609c68",
-                "sha256:07dbb28d20935db2609970f64b34808da944f922e8bce9013e87d9f9eabe6511",
-                "sha256:145be4da15d05d81a197c738b02f7e3e0496b6181088c5c9e5ac95aa8e2b6993",
-                "sha256:1c4e36c1939d2b375db99d5d32f43e509cbaf581c1f3db717981c2b0108d6b05",
-                "sha256:1f45f23c8b89af79286aba1abf65f30180eb00920581f50509e5c7e33cb12576",
-                "sha256:2114801a33f08d02c4ea6d5a703660700a6a04dfd3bb4bd76d3214d97017717f",
-                "sha256:26dc278d9022a8ddc86ab896dda6a33bcb629bb8bc57f34a57cd84c9d4003ea7",
-                "sha256:2e6bf4a5b433fccad6f302a58f7facc1551ff1f92d70c59231c87db5b84325f1",
-                "sha256:345ac0acaabb186fe52f33546ef4d8d2e1f7a2f6cc5039fd72d1289723b27703",
-                "sha256:4044164df9b975377c2761789fb50e1ebffba255a1bfee038c86044c0d0fa123",
-                "sha256:481602a0b7f0dd419042ac38b16c99b7e362ead05eb34f599cc07571f0f0a4b1",
-                "sha256:525695e66ecd837063173e2bddc693489b4a19e0553a820ce17f8950a5b600e6",
-                "sha256:530d42a05db678860f548e7f11a263fc270cf49a693e5001c52846b66c3dae96",
-                "sha256:959c2025815b4a792b3535afb0f74af2e276b470eea0e1bc202563c7f387daaa",
-                "sha256:9b212bd47946aba8d264a4b2ad1598c2be5e76466eed04f466871f3982e8b2e8",
-                "sha256:9b8c67a34876cf11181d7700e3b9e24d79d8dc8811f35f1fbaac867af8624417",
-                "sha256:a1ab7c876d2a07fc2fecff5141a073887d10c63cd3f880d7280d0f795bf18b2f",
-                "sha256:b1f73f7c84d96f949b4da5ea573317bb43a372c0a6a7104e9f5dcd7097ebcb89",
-                "sha256:b637371ff4c26c1f5accf64a9d4a454eef0788bbd79fe3600f4fefb79c29e8f3",
-                "sha256:b94aec4cfe299f00abfb2004ef62b564e1f52c2d2c66c7628c3cd144aeb37f46",
-                "sha256:c3c4e0864ef2af1418ac961a0dd065475f15f07fc5d5bf0030c2e39bddd34d49",
-                "sha256:c92dd3ac31f2d8d1893fd45ca9fbd7059a820d4d078f78ebb5179ea33eebc18e",
-                "sha256:d62a1a9cc2416c2be78f980e49987f5b2062f5a758d6c8d873efac06ba78a9c0",
-                "sha256:dd74d0d470baf1c50e31335215793a5e78436903e34b4f151fa9ccbf3a6cc20c",
-                "sha256:ebb3f3f9f3f25248e5e622256da72180c0f56b3e72d94e3318423e87bad81f5c",
-                "sha256:f0cd8f99d28c6e148cbd62d7f07821148be3323989f18ba8a713bedef87a8355"
+                "sha256:161a282a208a5705e01cb4c2081c32eeac1264c27f1069972475515ea9f212d7",
+                "sha256:18a9ef24d0b7191f759080ed23ac9a4ceb99fa274dc7f2b6008d7ea6743e4367",
+                "sha256:2c48824d4bec47912ca3d4c911e78e59eb385cc913df693708cc7411013b4bf8",
+                "sha256:33cc0f0db06b2559a17b4033186e254bce14f3240b076682559347a846e0df9f",
+                "sha256:3faa5844186b380b190dc0081252839e46c0a199f40970eadb57241d3e9cee64",
+                "sha256:437b82e6284403f14f45956cd30f8828cdb6623b554c8caca71281d87341aa5e",
+                "sha256:4850175eca56afc04eec884db9fc1398b19c1e6a6d3f14706c864106039cfd36",
+                "sha256:52165b8286f8c4c1b65ef6ce498b0708dd5801ac476e2b8d2e7c790755ebb885",
+                "sha256:5660098bd6a040b202e35f2d1b1f797355100809fb0fe1cda2a40242538d0ff0",
+                "sha256:576734983e231cb7a299f351db7ce2ba39d92f6834629400d0abc13cde5ecf9f",
+                "sha256:5f91a34743b718d0cc084c1def6e86b11d7c293de441ac9c55aaf497b7870884",
+                "sha256:6af7518121e4245b7afaf329a307ed681c02416f8de8dcfe219d69f3a521a163",
+                "sha256:6e8cf40a3cf9aabde1c6ef497659cabdeb3d165153dcdfa9256c0b3fa0c89e6a",
+                "sha256:7ff8012b0409358c2f137e322356d5c99b6bc9cbee7b8f207dae72c65e096393",
+                "sha256:81cfe72ec4dcf24f6eee101a8cadcaf472de0599192641fde91c05bda607bf8c",
+                "sha256:8c925dab2b81e192f48af8a03334b722f8f8943f3c322552d40452e0971dd737",
+                "sha256:91039e73d07c2db48557339028b5eabe9b74b969494cb651219363f093f27b2d",
+                "sha256:9151f16749b2243053bd538e952c30186cb1ddf8a7483d488c5cc053f5672009",
+                "sha256:926ce8d96cdc42ac8c1195379eaed01fcb50601fb298291695eee981ea8da293",
+                "sha256:976bbd01a687c93653632421e86921efc0371f4b6b455a82dd3fef87174d2acb",
+                "sha256:9c723f93694a6cc84e8e592a2c21c17cec9c5931325665e5b82d372e1d1ab6c0",
+                "sha256:9d5855744a23148f82fc6b70a9791cdd379660e48529d68d902f515d8639d8f5",
+                "sha256:a8ea8012878ebe78aecbf1ed0d7a842e9fbf2b3088dd85f1c00b91ec71ab0d31",
+                "sha256:b43dfc5cc912bacd09ccc89ed2c4f57afd70e979ca1bdb9ed5a65a1ccbfee3f8",
+                "sha256:c38d685e28365269eabdcad07dce16ddc3bda6b163461e171a655f2c1e2ea06b",
+                "sha256:d65d600dac4bb3652a1b6baf64653d90e1dbe0e1fc17090beff680dcbfcfcc59",
+                "sha256:d900adef5c270dc4671778768b5d3ef23cc438a40342541e4a8de8a0ca60dbab",
+                "sha256:da687d9c6d20074a3a6ba0de9b3be0a719e82ed6c947252211da136ef8db8c63",
+                "sha256:dc6f5015f26e05245350d46f3d9563f90cb5b13ade97db43f1b3d690660ca5e5",
+                "sha256:e1fea388aac3d1acebde4cb1c793d907fd1b56190aefeec1b66c9e939d0a135e",
+                "sha256:e48ca99ae2ae69d4b08e759dfd65104cc0fde6f4ce9f8fcf591efe9d47c4382e",
+                "sha256:e5f31baf81b7a2e94768135cee5ddff1fd4f6ebcbe7214cc4a611d92f67cfcd1",
+                "sha256:e785f6ddd73063de5db217f439f6d73446b11ba536f4e6641fa4a1d48a28e9bd",
+                "sha256:ee62e7992ef040e8d3cfdc006b74af79adccbd706dcb5b5b3b013a29d425f818",
+                "sha256:f051d3f8058a038bf051106d56ab5ab4338b88fcd4b54067a27f90482e7f5548",
+                "sha256:f1279192e59dbecf5eda56c29596f5e36e3e365a6dbc722933f52a47507f845a",
+                "sha256:f8f40f701b4ef2a4bf4c8e827b8acc7886bb9dd93cf2204b4bc81d9352c69312"
             ],
-            "version": "==1.0.3.4"
+            "version": "==1.0.4"
         },
         "chardet": {
             "hashes": [
@@ -136,6 +152,40 @@
                 "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"
             ],
             "version": "==0.10.0"
+        },
+        "cython": {
+            "hashes": [
+                "sha256:07efba7b32c082c519b75e3b03821c2f32848e2b3e9986c784bbd8ffaf0666d7",
+                "sha256:08db41daf18fabf7b7a85e39aa26954f6246994540043194af026c0df65a4942",
+                "sha256:19bbe3caf885a1d2e2c30eacc10d1e45dbbefb156493fe1d5d1adc1668cc1269",
+                "sha256:1c574f2f2ba760b82b2bcf6262e77e75589247dc5ef796a3ff1b2213e50ee452",
+                "sha256:1dfe672c686e34598bdbaa93c3b30acb3720ae9258232a4f68ba04ee9969063d",
+                "sha256:283faea84e6c4e54c3f5c8ff89aa2b6c1c3a813aad4f6d48ed3b9cc9043ef9f9",
+                "sha256:2a145888d0942e7c36e86a7b7c7e2923cb9f7055805a3b72dcb137e3efdb0979",
+                "sha256:3f75065936e16569d6e13dfd76de988f5eabeae460aa54770c9b961ab6f747fc",
+                "sha256:4d78124f5f281f1d5d5b7919cbbc65a7073ff93562def81ee78a8307e6e72494",
+                "sha256:5ba4d088b8e5d59b8a5911ca9c72952acf3c83296b57daf75af92fb2af1e8423",
+                "sha256:6b19daeda1d5d1dfc973b291246f6a63a663b20c33980724d6d073c562719536",
+                "sha256:790c7dc80fd1c3e38acefe06027e2f5a8466c128c7e47c6e140fd5316132574d",
+                "sha256:7f8c4e648881454ba3ba0bcf3b21a9e1878a67d20ea2b8d9ec1c4c628592ab6b",
+                "sha256:8bcd3f597290f9902548d6355898d7e376e7f3762f89db9cd50b2b58429df9e8",
+                "sha256:8ffb18f71972a5c718a8600d9f52e3507f0d6fb72a978e03270d34a7035c98fb",
+                "sha256:92f025df1cb391e09f65775598c7dfb7efad72d74713775db54e267f62ca94a1",
+                "sha256:93cf1c72472a2fd0ef4c52f6074dab08fc28d475b9c824ba73a52701f7a48ae1",
+                "sha256:9a7fa692cdc967fdbf6a053c1975137d01f6935dede2ef222c71840b290caf79",
+                "sha256:a68eb0c1375f2401de881692b30370a51e550052b8e346b2f71bbdbdc74a214f",
+                "sha256:ac3b7a12ddd52ea910ee3a041e6bc65df7a52f0ba7bd10fb7123502af482c152",
+                "sha256:b402b700edaf571a0bae18ec35d5b71c266873a6616412b672435c10b6d8f041",
+                "sha256:c29d069a4a30f472482343c866f7486731ad638ef9af92bfe5fca9c7323d638e",
+                "sha256:d822311498f185db449b687336b4e5db7638c8d8b03bdf10ae91d74e23c7cc0c",
+                "sha256:dccc8df9e1ac158b06777bbaaeb4516f245f9b147701ae25e6023960e4a0c2a3",
+                "sha256:e31f4b946c2765b2f35440fdb4b00c496dfc5babc53c7ae61966b41171d1d59f",
+                "sha256:eb43f9e582cc221ee2832e25ea6fe5c06f2acc9da6353c562e922f107db12af8",
+                "sha256:f07822248110fd6213db8bc2745fdbbccef6f2b3d18ac91a7fba29c6bc575da5",
+                "sha256:ff69854f123b959d4ae14bd5330714bb9ee4360052992dc0fbd0a3dee4261f95"
+            ],
+            "index": "pypi",
+            "version": "==0.29.13"
         },
         "dask": {
             "extras": [
@@ -207,6 +257,14 @@
                 "sha256:6531a5fa9ea6bf27a5180d225558a8a7aa5d7c3cbf7e8b146dd37ac699017937"
             ],
             "version": "==0.5.2"
+        },
+        "geoviews": {
+            "hashes": [
+                "sha256:0718fd6adaf65ff44a250959205aad9737a310db14caf0aee6f8d4e12b224771",
+                "sha256:3bd1eedbf0081d415daa41b9fcf176b4eae113df0f178f69a4c2f881c9003c01"
+            ],
+            "index": "pypi",
+            "version": "==1.6.5"
         },
         "h5netcdf": {
             "hashes": [
@@ -600,33 +658,29 @@
         },
         "netcdf4": {
             "hashes": [
-                "sha256:0c72bfb047cb08fb2567cda7944f96c36d0c3f0f14c14618aabc3f772c120f4b",
-                "sha256:152e293d5046f4fbec67973c568c7683364f3718fd44be8f7c59432f2c5d08db",
-                "sha256:1a8372f757f753ad32e42201d025c6166199dbd106d00d0423d7e7f3c5cb56f5",
-                "sha256:2396f99cedc7fd8cb8a92849b1fb94dd03ba0670d26f3589a4eba35f96700d96",
-                "sha256:263af7db1decf498dc94dc49646c168c97f0fd049712b14a952e87680c62594e",
-                "sha256:26e019ce1188944803cf530f15b6c2dae7aab43d2d76171ce993809878560d9c",
-                "sha256:32a533faf74733cd2dbe507b9da895988db7f301df3515e365473cea7e733fd8",
-                "sha256:3350d74f8473155e6197c2217da478375f118df690e8f34dd63a83467e66b244",
-                "sha256:56c70760c74bd7dc28cefd117dc1e1e105229f4410e50d22b27f8891c3a80889",
-                "sha256:575c518b41436e5070f4b5f96bc484a913a40e50656c1523762e4213a7fcca62",
-                "sha256:5892ba5feb5ed14eff76d0c366bcfbb135b98f7a6f85b457ad5e6764d8076c5a",
-                "sha256:7e8d2f0f3e0c0e0b4712770ce0f28b4fd3eb7143aec915dce73d1cf41c90fea7",
-                "sha256:80c179f42b84895dac311f886d0102b67bd1b71f5815fa158d335edb91fd56f2",
-                "sha256:848b2eae29ae56199f3840a7a1eb18b9235d2cbeff9f9495fabdfd805f3cd005",
-                "sha256:8659cd00bcf2dd2042707f485dfd550de28827c4788051815e0ea9802fe96df7",
-                "sha256:8d0058da1c5f97dbf79f54a3559fa68b19ce935e121712230047b05708a9f75c",
-                "sha256:9467269d2f813832894b0d2a4ee492e4b659858bd64406307f58223c49f26073",
-                "sha256:c94b7bd57a1ab45b3a95741e0f807f678bf1e16f3b7783e82d285c9b8577ed5d",
-                "sha256:c9d32e368082d4362493b28ceb3cd710af15c608a04b6028274c1b164bfb7007",
-                "sha256:ca8a5458ae381e3fb10929f80915d9093604f501ce71bba5ab73047825d56ffc",
-                "sha256:cc419d588bffd6c4478bd5f98d7a99c9c4de34a7f3aeaaa468934519603b83df",
-                "sha256:e075e1937ae5b297292c22adb72d7fdf557ba7509e6fd967fec133f1be178922",
-                "sha256:ebcac3f5470c13aa0483fc9d35fc3e4254b1ff43206fb061d2eea62ba9f03123",
-                "sha256:f76fd842b840b8b443cd28525997663fd2ce4c53be6dd214519f7210cbd0b613",
-                "sha256:fcc7a4f938f0c62117291408c08192fd69195f53df57ed4c02f04dd78ba29746"
+                "sha256:01fcd8a7eb9cd711f94ab2422a41f4fb984d7884c7761ad1394bda114f4598dc",
+                "sha256:1a1f4c660e245c25f4ddde596f2b8e605d31ed843bccb3edf427e95b52460292",
+                "sha256:2a3ca855848f4bbf07fac366da77a681fcead18c0a8813d91d46302f562dc3be",
+                "sha256:2acb00d49924c6f7333644e63395b9baacc004d5b9d91a336ce48087cf777aea",
+                "sha256:387500a82e6f1d6a8bb8c59bb04c29c5c889a2096598b94bd5445dfe4f3d5bc8",
+                "sha256:43fd12e87661a503802bc2e439f6f0771e81c61084a31a85baf60a27c33710ce",
+                "sha256:561a36c0913a859254048f4ddfa94670ef46e3d4dc35b54d4cc4ec26e36e7870",
+                "sha256:654236cb5ef0f717851e0174ba828bd39d2d24a35ed5f512712ffd5a74f68048",
+                "sha256:66802ada8cd691a77087777b9a3d7aea7eeeefce5b731f3f064c245289de743e",
+                "sha256:673fa90736017daf498d2521bd1670e9024bef87b97e2d45f189ce1b6a532a7d",
+                "sha256:86eb62fe4adf89e482fbf9f81b1cca3232ce460747bf8161ef2dcbb64eb27a1d",
+                "sha256:9305604521e2d504156bb1fb6379314bc04b611021f7f713dc41b1caf701f1d9",
+                "sha256:b2e6af17a76ee8b9f8086b2d9d945032a5c08cedd9cf49ae1589530f2ebec9e3",
+                "sha256:baf112ba8fef6ae69d8e84a48c970d669b9751f6fda485be473b9ff6d819bf90",
+                "sha256:bcc321f975045883e08c3dbad5f609adcb041df77c421518d36a0d253a6e3779",
+                "sha256:c93a4a0429e666bc2641c1a84af3381e5689b7afb5eac4154b90b1e490d7f3c8",
+                "sha256:c98ceae290e87c0b2d4828f2bec8100fda6d15b71bf03b0f0a182a220939d860",
+                "sha256:c9ff82a07db6fb97800b329fa84f85031f403e98127c919eea95881a495b4281",
+                "sha256:cc9ce70a6323a7f0a5e94fdd7b149a49dc93586f73ee872778b7cab2efa80a96",
+                "sha256:dbb1cf68d66b4f692ecdc6921990e0553fae9baf5bbb67086c1f9f8917367d5a",
+                "sha256:f73988fb8e4b688e3945c1584f0f45ce3d96a95e2bcbd53ed73eb0611d7cb294"
             ],
-            "version": "==1.5.2"
+            "version": "==1.5.3"
         },
         "networkx": {
             "hashes": [
@@ -782,34 +836,38 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:00fdeb23820f30e43bba78eb9abb00b7a937a655de7760b2e09101d63708b64e",
-                "sha256:01f948e8220c85eae1aa1a7f8edddcec193918f933fb07aaebe0bfbbcffefbf1",
-                "sha256:08abf39948d4b5017a137be58f1a52b7101700431f0777bec3d897c3949f74e6",
-                "sha256:099a61618b145ecb50c6f279666bbc398e189b8bc97544ae32b8fcb49ad6b830",
-                "sha256:2c1c61546e73de62747e65807d2cc4980c395d4c5600ecb1f47a650c6fa78c79",
-                "sha256:2ed9c4f694861642401f27dc3cb99772be67cd190e84845c749dae0a06c3bfae",
-                "sha256:338581b30b908e111be578f0297255f6b57a51358cd16fa0e6f664c9a1f88bff",
-                "sha256:38c7d48a21cd06fdeee93987147b9b1c55b73b4cfcbf83240568bfbd5adee447",
-                "sha256:43fd026f613c8e48a25eba1a92f4d2ad7f3903c95d8c33a11611a7717d2ab654",
-                "sha256:4548236844327a718ce3bb182ab32a16fa2050c61e334e959f554cac052fb0df",
-                "sha256:5090857876c58885cfa388dc649e5db30aae98a068c26f3fd0ac9d7d9a4d9572",
-                "sha256:5bbba34f97a26a93f5e8dec469ca4ddd712451418add43da946dbaed7f7a98d2",
-                "sha256:65a28969a025a0eb4594637b6103201dc4ed2a9508bdab56ac33e43e3081c404",
-                "sha256:892bb52b70bd5ea9dbbc3ac44f38e84f5a04e9d8b1bff48159d96cb795b81159",
-                "sha256:8a9becd5cbd5062f973bcd2e7bc79483af310222de112b6541f8af1f93a3cc42",
-                "sha256:972a7aaeb7c4a2795b52eef52ee991ef040b31009f36deca6207a986607b55f3",
-                "sha256:97b119c436bfa96a92ac2ca525f7025836d4d4e64b1c9f9eff8dbaf3ff1d86f3",
-                "sha256:9ba37698e242223f8053cc158f130aee046a96feacbeab65893dbe94f5530118",
-                "sha256:b1b0e1f626a0f079c0d3696db70132fb1f29aa87c66aecb6501a9b8be64ce9f7",
-                "sha256:c14c1224fd1a5be2733530d648a316974dbbb3c946913562c6005a76f21ca042",
-                "sha256:c79a8546c48ae6465189e54e3245a97ddf21161e33ff7eaa42787353417bb2b6",
-                "sha256:ceb76935ac4ebdf6d7bc845482a4450b284c6ccfb281e34da51d510658ab34d8",
-                "sha256:e22bffaad04b4d16e1c091baed7f2733fc1ebb91e0c602abf1b6834d17158b1f",
-                "sha256:ec883b8e44d877bda6f94a36313a1c6063f8b1997aa091628ae2f34c7f97c8d5",
-                "sha256:f1baa54d50ec031d1a9beb89974108f8f2c0706f49798f4777df879df0e1adb6",
-                "sha256:f53a5385932cda1e2c862d89460992911a89768c65d176ff8c50cddca4d29bed"
+                "sha256:047d9473cf68af50ac85f8ee5d5f21a60f849bc17d348da7fc85711287a75031",
+                "sha256:0f66dc6c8a3cc319561a633b6aa82c44107f12594643efa37210d8c924fc1c71",
+                "sha256:12c9169c4e8fe0a7329e8658c7e488001f6b4c8e88740e76292c2b857af2e94c",
+                "sha256:248cffc168896982f125f5c13e9317c059f74fffdb4152893339f3be62a01340",
+                "sha256:27faf0552bf8c260a5cee21a76e031acaea68babb64daf7e8f2e2540745082aa",
+                "sha256:285edafad9bc60d96978ed24d77cdc0b91dace88e5da8c548ba5937c425bca8b",
+                "sha256:384b12c9aa8ef95558abdcb50aada56d74bc7cc131dd62d28c2d0e4d3aadd573",
+                "sha256:38950b3a707f6cef09cd3cbb142474357ad1a985ceb44d921bdf7b4647b3e13e",
+                "sha256:4aad1b88933fd6dc2846552b89ad0c74ddbba2f0884e2c162aa368374bf5abab",
+                "sha256:4ac6148008c169603070c092e81f88738f1a0c511e07bd2bb0f9ef542d375da9",
+                "sha256:4deb1d2a45861ae6f0b12ea0a786a03d19d29edcc7e05775b85ec2877cb54c5e",
+                "sha256:59aa2c124df72cc75ed72c8d6005c442d4685691a30c55321e00ed915ad1a291",
+                "sha256:5a47d2123a9ec86660fe0e8d0ebf0aa6bc6a17edc63f338b73ea20ba11713f12",
+                "sha256:5cc901c2ab9409b4b7ac7b5bcc3e86ac14548627062463da0af3b6b7c555a871",
+                "sha256:6c1db03e8dff7b9f955a0fb9907eb9ca5da75b5ce056c0c93d33100a35050281",
+                "sha256:7ce80c0a65a6ea90ef9c1f63c8593fcd2929448613fc8da0adf3e6bfad669d08",
+                "sha256:809c19241c14433c5d6135e1b6c72da4e3b56d5c865ad5736ab99af8896b8f41",
+                "sha256:83792cb4e0b5af480588601467c0764242b9a483caea71ef12d22a0d0d6bdce2",
+                "sha256:846fa202bd7ee0f6215c897a1d33238ef071b50766339186687bd9b7a6d26ac5",
+                "sha256:9f5529fc02009f96ba95bea48870173426879dc19eec49ca8e08cd63ecd82ddb",
+                "sha256:a423c2ea001c6265ed28700df056f75e26215fd28c001e93ef4380b0f05f9547",
+                "sha256:ac4428094b42907aba5879c7c000d01c8278d451a3b7cccd2103e21f6397ea75",
+                "sha256:b1ae48d87f10d1384e5beecd169c77502fcc04a2c00a4c02b85f0a94b419e5f9",
+                "sha256:bf4e972a88f8841d8fdc6db1a75e0f8d763e66e3754b03006cbc3854d89f1cb1",
+                "sha256:c6414f6aad598364aaf81068cabb077894eb88fed99c6a65e6e8217bab62ae7a",
+                "sha256:c710fcb7ee32f67baf25aa9ffede4795fd5d93b163ce95fdc724383e38c9df96",
+                "sha256:c7be4b8a09852291c3c48d3c25d1b876d2494a0a674980089ac9d5e0d78bd132",
+                "sha256:c9e5ffb910b14f090ac9c38599063e354887a5f6d7e6d26795e916b4514f2c1a",
+                "sha256:e0697b826da6c2472bb6488db4c0a7fa8af0d52fa08833ceb3681358914b14e5",
+                "sha256:e9a3edd5f714229d41057d56ac0f39ad9bdba6767e8c888c951869f0bdd129b0"
             ],
-            "version": "==6.2.0"
+            "version": "==6.2.1"
         },
         "prometheus-client": {
             "hashes": [
@@ -865,6 +923,14 @@
             "index": "pypi",
             "version": "==3.2.2"
         },
+        "pyepsg": {
+            "hashes": [
+                "sha256:2d08fad1e7a8b47a90a4e43da485ba95705923425aefc4e2a3efa540dbd470d7",
+                "sha256:ecb29d351f66221d951989f7443f747be0b078162e71384c96612764e18265eb"
+            ],
+            "index": "pypi",
+            "version": "==0.4.0"
+        },
         "pygments": {
             "hashes": [
                 "sha256:71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127",
@@ -879,11 +945,38 @@
             ],
             "version": "==2.4.2"
         },
+        "pyproj": {
+            "hashes": [
+                "sha256:0f3b3280ae59c74212841c38d1df055537b4e83cbfcda4072ba6b0eeefd0b98a",
+                "sha256:36ad4ff82f38cdc7738da81289ec4309263ad40f3d62cb75eeef22bb70178698",
+                "sha256:4a26485f09052722deaa1ddc6b3133d41bd982be5b0e64e296626e71b94ee5e6",
+                "sha256:4b41db92d689119b57ff6fcc3ae5a75072c86a7078cb0c25434b3ab4b79ad624",
+                "sha256:5d1f4f2645abd05128d29bd71eb378ff0fedb9f96147356e68b87a628863bf92",
+                "sha256:7c05ca74d7a3c822afd933e2efb5c599475c1cb22919500cb7df8ecb1c24d04e",
+                "sha256:8124fe43d81a7caca43df6930110e2bfd2bd3b82b86587eefd6f6d86a81a658e",
+                "sha256:8e2a8fab431bc6d16a417792198813fe6b8c53aafb51f54e1e6a52cdb377b576",
+                "sha256:9121e2ae3eb13d32cf2c49e456e052fe88cab200cfc07e3162cdb276427040fa",
+                "sha256:a8462505b4fa7e7e73ac5e69f1aa3d4a31b25e93dac80a41a2ff35d996c3f173",
+                "sha256:c22c52ea26d318d808bdde23e2b57b85c292747971ff79d0ea578b578ff791d6",
+                "sha256:d25638d48af3df03c6d3c713495d62d0b9a135032b0dddafbb7f0004d052b1f5",
+                "sha256:d851dd9245f60871306a49af92523a8ea8d8a60f3e522bbd8b9cd512d8b825ec",
+                "sha256:e27a5bec46c706a343db9b218bf13abd53f1e066668b194bd48511c1773f6c1c",
+                "sha256:fb151507b8793acc8c622164e3cc57d0c51f3d4790dabba1daf141a780bad68a"
+            ],
+            "index": "pypi",
+            "version": "==2.4.0"
+        },
         "pyrsistent": {
             "hashes": [
                 "sha256:34b47fa169d6006b32e99d4b3c4031f155e6e68ebcc107d6454852e8e0ee6533"
             ],
             "version": "==0.15.4"
+        },
+        "pyshp": {
+            "hashes": [
+                "sha256:e65c7f24d372b97d0920b864bbeb78322bb37b83f2606e2a2212631d5d51e5c0"
+            ],
+            "version": "==2.1.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -989,18 +1082,19 @@
         },
         "scikit-image": {
             "hashes": [
-                "sha256:00bbc1d6702c6fe6948a3b9ebd05c0d4cfc49e7a058b87f44ca599e75eadecce",
-                "sha256:084ecd3dc7ef32bc8725a78b2722012d3e8385c446e812dae2792ce2e9111225",
-                "sha256:2a874c5864fe686780e2863fb4c323f0ebcd2cb4e4b9b650def54e66e6f12ac0",
-                "sha256:41f6410054011e1b015af658d3916221cb97964d648c92d533a2144ca7657e62",
-                "sha256:4fbdbe217ac070dd98bd42ad02872f27ab96b4f5e1fdca6952cff5ffe81c2170",
-                "sha256:655c7ab92ac3e3bdf9bee47d24784e5b4d9abd127f8732df7c8de89f95b254b1",
-                "sha256:7d7f43f067ccb82aa335cd0af1de606dfa12193b4551baa8c16be0ecb76a49a9",
-                "sha256:824fe3e6a06c64f264aa94e59687d8bb7523ffc6778dad958d388e993f5aaecd",
-                "sha256:b819ac00c298c98ff18266756339e5c5a3682d13d280eb8d4b226582455f249d",
-                "sha256:f1508b1eddd49c816b3bcae14a4d3eb921f2623559cdae87a0d11133b36ee36d"
+                "sha256:063d1c20fcd53762f82ee58c29783ae4e8f6fbed445b41b704fa33b6f355729d",
+                "sha256:0808ab5f8218d91a1c008036993636535a37efd67a52ab0f2e6e3f4b7e75aeda",
+                "sha256:2a54bea469eb1b611bee1ce36e60710f5f94f29205bc5bd67a51793909b1e62b",
+                "sha256:2aa962aa82d815606d7dad7f045f5d7ca55c65b4320d47e15a98fc92612c2d6c",
+                "sha256:2d346d49b6852cffb47cbde995e2696d5b07f688d8c057a0a4548abf3a98f920",
+                "sha256:3ad2efa792ab8de5fcefe6f4f5bc1ab64c411cdb5c829ce1526ab3a5a7729627",
+                "sha256:3af3d781ce085573ced37b2b5b9abfd32ce3d4723bd17f37e829025d189b0421",
+                "sha256:6786b127f33470fd843e644435522fbf43bce05c9f5527946c390ccb9e1cac27",
+                "sha256:8b2b768b02c6b7476f2e16ddd91f827d3817aef73f82cf28bff7a8dcdfd8c55c",
+                "sha256:dd7fbd32da74d4e9967dc15845f731f16e7966cee61f5dc0e12e2abb1305068c",
+                "sha256:e774377876cb258e8f4d63f7809863f961c98aa02263b3ff54a39483bc6f7d26"
             ],
-            "version": "==0.16.1"
+            "version": "==0.16.2"
         },
         "scipy": {
             "hashes": [
@@ -1029,6 +1123,23 @@
                 "sha256:f1691922577b6fa12821234aeb57599d887c4900b9ca537948d2dac34aea888b"
             ],
             "version": "==1.5.0"
+        },
+        "shapely": {
+            "hashes": [
+                "sha256:0378964902f89b8dbc332e5bdfa08e0bc2f7ab39fecaeb17fbb2a7699a44fe71",
+                "sha256:34e7c6f41fb27906ccdf2514ee44a5774b90b39a256b6511a6a57d11ffe64999",
+                "sha256:3ca69d4b12e2b05b549465822744b6a3a1095d8488cc27b2728a06d3c07d0eee",
+                "sha256:3e9388f29bd81fcd4fa5c35125e1fbd4975ee36971a87a90c093f032d0e9de24",
+                "sha256:3ef28e3f20a1c37f5b99ea8cf8dcb58e2f1a8762d65ed2d21fd92bf1d4811182",
+                "sha256:523c94403047eb6cacd7fc1863ebef06e26c04d8a4e7f8f182d49cd206fe787e",
+                "sha256:5d22a1a705c2f70f61ccadc696e33d922c1a92e00df8e1d58a6ade14dd7e3b4f",
+                "sha256:714b6680215554731389a1bbdae4cec61741aa4726921fa2b2b96a6f578a2534",
+                "sha256:7dfe1528650c3f0dc82f41a74cf4f72018288db9bfb75dcd08f6f04233ec7e78",
+                "sha256:ba58b21b9cf3c33725f7f530febff9ed6a6846f9d0bf8a120fc74683ff919f89",
+                "sha256:c4b87bb61fc3de59fc1f85e71a79b0c709dc68364d9584473697aad4aa13240f",
+                "sha256:ebb4d2bee7fac3f6c891fcdafaa17f72ab9c6480f6d00de0b2dc9a5137dfe342"
+            ],
+            "version": "==1.6.4.post2"
         },
         "six": {
             "hashes": [

--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,10 @@ name: deepicedrain
 channels:
   - conda-forge
 dependencies:
+  - rapidsai::cuspatial=0.11.0[md5=72cd66b7cc0171f55e49c6454f524efd]
   - conda-forge::gxx_linux-64=7.3.0[md5=c22eb25a5719c7c4f202d1f028a65bff]
   - conda-forge::pip=19.2.3[md5=b475ca5f9afba8ab1203a413caa8e9ad]
-  - conda-forge::proj=6.2.0[md5=c580a8a32fa571b1f16a3936d3ba9cfd]
+  - conda-forge::proj=6.2.1[md5=648fa04e8ad91cbf483ea0caa175afe3]
   - conda-forge::python=3.7.3[md5=e9385633516bf38da68e983b4f8b9e2a]
   - conda-forge::shapely=1.6.4[md5=0ab81ce5446096b2d6c8c088638565fa]
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,8 @@ channels:
 dependencies:
   - conda-forge::gxx_linux-64=7.3.0[md5=c22eb25a5719c7c4f202d1f028a65bff]
   - conda-forge::pip=19.2.3[md5=b475ca5f9afba8ab1203a413caa8e9ad]
+  - conda-forge::proj=6.2.0[md5=c580a8a32fa571b1f16a3936d3ba9cfd]
   - conda-forge::python=3.7.3[md5=e9385633516bf38da68e983b4f8b9e2a]
+  - conda-forge::shapely=1.6.4[md5=0ab81ce5446096b2d6c8c088638565fa]
   - pip:
     - pipenv==2018.11.26


### PR DESCRIPTION
Improving [conda](https://github.com/conda/conda) and [pipenv](https://github.com/pypa/pipenv) interoperability! Necessary for those hard to install geospatial packages like [cartopy](https://github.com/SciTools/cartopy), and [cuspatial](https://github.com/rapidsai/cuspatial) (only available through conda).

In other words, running `conda list` should show pipenv installed packages, and running `pip list` should show Python packages installed by conda. This is possible with conda versions > 4.6 (https://github.com/conda/conda/issues/7053) and pipenv since 2018 (https://github.com/pypa/pipenv/issues/1469).

References:
- https://stackoverflow.com/questions/50546339/pipenv-with-conda
- https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/pip-interoperability.html
- https://pipenv.readthedocs.io/en/latest/advanced/#pipenv-and-other-python-distributions
- https://www.anaconda.com/using-pip-in-a-conda-environment/

TODO:
- [x] Let conda see pip packages (5bb5b2324740acdfefea6444126dfeda0ad2ae2f)
- [x] Let pipenv use conda site-packages (2b234acf655c9ad77fa20a0e0c26accb6a9fe272)
- Add geospatial packages:
  - [x] geoviews with cartopy (90e6d124b310069334d1ad61200dbd648b9dc8fc)
  - [x] cuspatial (58fdcdffba5be03a12f29a6a7e1fd3f16a893586)

Note to future self, may want to consider refactoring Dockerfile to be more space efficient through some ingenious use of the cache/multi-build stages.