### PR TITLE
Enable interactive PyViz plots properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,11 @@ RUN conda activate deepicedrain && \
     rm --recursive ${HOME}/.cache/pip && \
     poetry show
 
+# Install jupyterlab extensions
+RUN conda activate deepicedrain && \
+    jupyter labextension install @pyviz/jupyterlab_pyviz && \
+    jupyter labextension list
+
 # Setup DeepBedMap virtual environment properly
 RUN conda activate deepicedrain && \
     python -m ipykernel install --user --name deepicedrain && \

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Finally, double-check that the libraries have been installed.
 
     poetry show
 
+(Optional) Install jupyterlab extensions for interactive [bokeh](https://bokeh.org) visualizations.
+
+    jupyter labextension install @pyviz/jupyterlab_pyviz
+
+    jupyter labextension list  # ensure that extension is installed
+
 ## Running jupyter lab
 
     conda activate deepicedrain

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - conda-forge::geos=3.8.1[md5=7282fbe0c036bacad959c03c05a7eb9a]
   - conda-forge::gmt=6.0.0[md5=dc8ef0c0d63b1fbd0caf761b939a5bc9]
   - conda-forge::gxx_linux-64=7.3.0[md5=170a667cc95fead22a9e38aba0e3486d]
-  - conda-forge::nodejs=14.3.0[md5=f3092f2e568ae5b2cf20b7637d24eafb]
+  - conda-forge::nodejs=13.13.0[md5=cf25f8cee7aad7f417980872d34d8fd6]
   - conda-forge::parallel=20200322[md5=fdfd211013d373cd36126b6c059bc9e9]
   - conda-forge::pip=20.1[md5=db77ee5f3abc11201e877b7477e81d74]
   - conda-forge::poetry=1.0.5[md5=171d7400c2aae11e3a3a30055de3eaa7]

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - conda-forge::geos=3.8.1[md5=7282fbe0c036bacad959c03c05a7eb9a]
   - conda-forge::gmt=6.0.0[md5=dc8ef0c0d63b1fbd0caf761b939a5bc9]
   - conda-forge::gxx_linux-64=7.3.0[md5=170a667cc95fead22a9e38aba0e3486d]
+  - conda-forge::nodejs=14.3.0[md5=f3092f2e568ae5b2cf20b7637d24eafb]
   - conda-forge::parallel=20200322[md5=fdfd211013d373cd36126b6c059bc9e9]
   - conda-forge::pip=20.1[md5=db77ee5f3abc11201e877b7477e81d74]
   - conda-forge::poetry=1.0.5[md5=171d7400c2aae11e3a3a30055de3eaa7]

--- a/poetry.lock
+++ b/poetry.lock
@@ -97,18 +97,18 @@ category = "main"
 description = "Interactive plots and applications in the browser from Python"
 name = "bokeh"
 optional = false
-python-versions = "*"
-version = "1.4.0"
+python-versions = ">=3.6"
+version = "2.0.2"
 
 [package.dependencies]
 Jinja2 = ">=2.7"
 PyYAML = ">=3.10"
-numpy = ">=1.7.1"
+numpy = ">=1.11.3"
 packaging = ">=16.8"
 pillow = ">=4.0"
 python-dateutil = ">=2.1"
-six = ">=1.5.2"
-tornado = ">=4.3"
+tornado = ">=5"
+typing_extensions = ">=3.7.4"
 
 [[package]]
 category = "main"
@@ -371,11 +371,11 @@ category = "main"
 description = "GeoViews is a Python library that makes it easy to explore and visualize geographical, meteorological, and oceanographic datasets, such as those used in weather, climate, and remote sensing research."
 name = "geoviews"
 optional = false
-python-versions = ">=2.7"
-version = "1.7.0"
+python-versions = ">=3.6"
+version = "1.8.1"
 
 [package.dependencies]
-bokeh = ">=1.4.0,<2.0.0"
+bokeh = ">=2.0.0"
 cartopy = ">=0.17.0"
 holoviews = ">=1.13.0"
 numpy = ">=1.0"
@@ -383,7 +383,7 @@ param = ">=1.9.2"
 
 [package.extras]
 all = ["coveralls", "datashader", "flake8", "gdal", "geopandas", "iris", "jupyter", "matplotlib (>2.2)", "mock", "nbsite (>=0.6.1)", "nbsmoke (>=0.2.0)", "netcdf4", "nose", "pandas", "pyct", "pyproj (<=2.1.3)", "pytest", "scipy", "selenium", "shapely", "sphinx-holoviz-theme", "xarray", "xesmf"]
-build = ["param (>=1.9.0)", "pyct (>=0.4.4)", "bokeh (>=1.4.0,<2.0.0)", "nodejs (>=9.11.1)", "setuptools"]
+build = ["param (>=1.9.0)", "pyct (>=0.4.4)", "bokeh (>=2.0.0)", "nodejs (>=10.13.0)", "setuptools"]
 doc = ["datashader", "geopandas", "gdal", "netcdf4", "jupyter", "matplotlib (>2.2)", "pandas", "pyct", "scipy", "shapely", "xarray", "iris", "xesmf", "mock", "nbsite (>=0.6.1)", "sphinx-holoviz-theme", "selenium", "pyproj (<=2.1.3)"]
 examples_extra = ["datashader", "geopandas", "gdal", "netcdf4", "jupyter", "matplotlib (>2.2)", "pandas", "pyct", "scipy", "shapely", "xarray", "iris", "xesmf", "mock"]
 recommended = ["datashader", "geopandas", "gdal", "netcdf4", "jupyter", "matplotlib (>2.2)", "pandas", "pyct", "scipy", "shapely", "xarray"]
@@ -1059,24 +1059,24 @@ category = "main"
 description = "A high level app and dashboarding solution for Python."
 name = "panel"
 optional = false
-python-versions = ">=2.7"
-version = "0.8.3"
+python-versions = ">=3.6"
+version = "0.9.5"
 
 [package.dependencies]
-bokeh = ">=1.4.0,<2.0"
+bokeh = ">=2.0.0"
 markdown = "*"
-param = ">=1.9.2"
+param = ">=1.9.3"
 pyct = ">=0.4.4"
-pyviz-comms = ">=0.7.3"
+pyviz-comms = ">=0.7.4"
 tqdm = "*"
 
 [package.extras]
-all = ["altair", "codecov", "datashader", "django", "flake8", "holoviews (>=1.12.0)", "hvplot", "jupyter-bokeh (<=1.1.1)", "lxml", "matplotlib", "nbsite (>=0.6.1)", "nbsmoke (>=0.2.0)", "notebook (>=5.4)", "parameterized", "phantomjs", "pillow", "plotly", "pytest", "pytest-cov", "pyvista", "scikit-learn", "scipy", "selenium", "sphinx-holoviz-theme", "streamz", "vega-datasets", "vtk"]
-build = ["param (>=1.9.2)", "pyct (>=0.4.4)", "setuptools (>=30.3.0)", "bokeh (>=1.4.0,<2.0)", "pyviz-comms (>=0.6.0)", "nodejs (>=9.11.1)"]
-doc = ["notebook (>=5.4)", "holoviews (>=1.12.0)", "matplotlib", "pillow", "plotly", "nbsite (>=0.6.1)", "sphinx-holoviz-theme", "selenium", "phantomjs", "lxml"]
-examples = ["hvplot", "plotly", "altair", "streamz", "vega-datasets", "vtk", "scikit-learn", "datashader", "jupyter-bokeh (<=1.1.1)", "django", "pyvista"]
-recommended = ["notebook (>=5.4)", "holoviews (>=1.12.0)", "matplotlib", "pillow", "plotly"]
-tests = ["flake8", "parameterized", "pytest", "scipy", "nbsmoke (>=0.2.0)", "pytest-cov", "codecov"]
+all = ["altair", "codecov", "datashader", "django", "flake8", "folium", "graphviz", "holoviews (>=1.13.2)", "hvplot", "jupyter-bokeh", "lxml", "matplotlib", "nbsite (>=0.6.1)", "nbsmoke (>=0.2.0)", "notebook (>=5.4)", "parameterized", "phantomjs", "pillow", "plotly", "pytest", "pytest-cov", "pyvista", "scikit-learn", "scipy", "selenium", "sphinx-holoviz-theme", "streamz", "vega-datasets", "vtk"]
+build = ["param (>=1.9.2)", "pyct (>=0.4.4)", "setuptools (>=30.3.0)", "bokeh (>=2.0.0)", "pyviz-comms (>=0.6.0)", "nodejs (>=9.11.1)"]
+doc = ["notebook (>=5.4)", "holoviews (>=1.13.2)", "matplotlib", "pillow", "plotly", "nbsite (>=0.6.1)", "sphinx-holoviz-theme", "selenium", "phantomjs", "graphviz", "lxml"]
+examples = ["hvplot", "plotly", "altair", "streamz", "vega-datasets", "vtk", "scikit-learn", "datashader", "jupyter-bokeh", "django", "pyvista"]
+recommended = ["notebook (>=5.4)", "holoviews (>=1.13.2)", "matplotlib", "pillow", "plotly"]
+tests = ["flake8", "parameterized", "pytest", "scipy", "nbsmoke (>=0.2.0)", "pytest-cov", "codecov", "folium"]
 
 [[package]]
 category = "main"
@@ -1584,6 +1584,14 @@ version = "1.4.1"
 
 [[package]]
 category = "main"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+name = "typing-extensions"
+optional = false
+python-versions = "*"
+version = "3.7.4.2"
+
+[[package]]
+category = "main"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
 optional = false
@@ -1683,7 +1691,7 @@ version = "2.0.0"
 heapdict = "*"
 
 [metadata]
-content-hash = "6d411f1b1caeed778b6a23b9824963a64695ec23750fb7168178f5e8ba3a8915"
+content-hash = "3b0413ab227a9e3c4c5133f34124e4e9589c682e6f2a75e18dbef49e013908bf"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -1720,7 +1728,7 @@ bleach = [
     {file = "bleach-3.1.4.tar.gz", hash = "sha256:e78e426105ac07026ba098f04de8abe9b6e3e98b5befbf89b51a5ef0a4292b03"},
 ]
 bokeh = [
-    {file = "bokeh-1.4.0.tar.gz", hash = "sha256:c60d38a41a777b8147ee4134e6142cea8026b5eebf48149e370c44689869dce7"},
+    {file = "bokeh-2.0.2.tar.gz", hash = "sha256:d9248bdb0156797abf6d04b5eac581dcb121f5d1db7acbc13282b0609314893a"},
 ]
 cartopy = [
     {file = "Cartopy-0.18.0.tar.gz", hash = "sha256:7ffa317e8f8011e0d965a3ef1179e57a049f77019867ed677d49dcc5c0744434"},
@@ -1845,8 +1853,8 @@ fsspec = [
     {file = "fsspec-0.7.3.tar.gz", hash = "sha256:1b540552c93b47e83c568e87507d6e02993e6d1b30bc7285f2336c81c5014103"},
 ]
 geoviews = [
-    {file = "geoviews-1.7.0-py2.py3-none-any.whl", hash = "sha256:1f720ab9bf06d976cd8c2831e7b3b124ef241c75b92469d80cd2ae6be8c6a946"},
-    {file = "geoviews-1.7.0.tar.gz", hash = "sha256:369fd3abcc19887746af96fc6a721cf19406e28c3f99f1ca9442c66dbdc281bb"},
+    {file = "geoviews-1.8.1-py2.py3-none-any.whl", hash = "sha256:bc944fde2c8ce8442d3a1c6a57c8f3958cdf5cdc1fbf12547a3a5fa86b079439"},
+    {file = "geoviews-1.8.1.tar.gz", hash = "sha256:7cf0c43b01b4aa623520a233d5f82e58b69febd58e22af328128f699f1c745fe"},
 ]
 h5netcdf = [
     {file = "h5netcdf-0.8.0-py2.py3-none-any.whl", hash = "sha256:3c06af4a8e049d2c0247dcc55101931974f9cdd84ffab8f4f60bd8f76ee3a331"},
@@ -2255,8 +2263,8 @@ pandocfilters = [
     {file = "pandocfilters-1.4.2.tar.gz", hash = "sha256:b3dd70e169bb5449e6bc6ff96aea89c5eea8c5f6ab5e207fc2f521a2cf4a0da9"},
 ]
 panel = [
-    {file = "panel-0.8.3-py2.py3-none-any.whl", hash = "sha256:9627e2ce5bbf5ba57c95633fadd0135e8dc93a25ecc05a3f541b550f64789a59"},
-    {file = "panel-0.8.3.tar.gz", hash = "sha256:cbca2ab87c9745e2cf3d3536a31104c0ba9cf7cf1e9541323005585ccf04e247"},
+    {file = "panel-0.9.5-py2.py3-none-any.whl", hash = "sha256:eaaa344cf5076b487821adad98fdfad8f72c43a0839d5ffb23332fb24bdb61b2"},
+    {file = "panel-0.9.5.tar.gz", hash = "sha256:53340615f30f67f3182793695ebe52bf25e7bbb0751aba6f29763244350d0f42"},
 ]
 param = [
     {file = "param-1.9.3-py2.py3-none-any.whl", hash = "sha256:b9afbfda25be81bd763a399beaf8775fd79156e5897d4de50d3e091d15d72636"},
@@ -2676,6 +2684,11 @@ typed-ast = [
     {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
     {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.2-py2-none-any.whl", hash = "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"},
+    {file = "typing_extensions-3.7.4.2-py3-none-any.whl", hash = "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5"},
+    {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
 ]
 urllib3 = [
     {file = "urllib3-1.25.8-py2.py3-none-any.whl", hash = "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ cartopy = "^0.18.0"
 cython = "^0.29.18"
 datashader = "^0.10.0"
 distributed = "^2.16.0"
-geoviews = "^1.7.0"
+geoviews = "^1.8.1"
 h5netcdf = "^0.8.0"
 intake = {extras = ["dataframe", "server"], version = "^0.5.5"}
 intake-xarray = { git = "https://github.com/intake/intake-xarray.git", rev = "bf98a3c69eea81be716b310e33aeefbf1a89b1d0" }


### PR DESCRIPTION
Back in the good old days, I could have sworn that [Holoviews](http://holoviews.org)+[Datashader](https://datashader.org) does dynamic updating when zooming into maps just like that (clicks fingers). In my old [ICESat-1 notebook](https://github.com/weiji14/cryospheric-data-lakes/blob/master/code/scripts/h5_to_np_icesat.ipynb) from Jan 2018, I was definitely plotting millions of (datashaded) points without any issues.

The trick now in the new decade seems to be :crossed_fingers: to install the [jupyter labextension](https://jupyterlab.readthedocs.io/en/stable/user/extensions.html) [`@pyviz/jupyterlab_pyviz`](https://www.npmjs.com/package/@pyviz/jupyterlab_pyviz) from npm as mentioned in https://hvplot.holoviz.org/getting_started/index.html#installation.

Because of some weird issue with my university network, I had to add `network-timeout 600000` to `.yarnrc` file (see https://github.com/yarnpkg/yarn/issues/5259#issuecomment-379769451) before going through a slightly more involved step:

```
jupyter labextension install @pyviz/jupyterlab_pyviz@v0.9.0 --no-build
jupyter labextension list  # check to see that extension is installed
jupyter lab build --debug  # build extension ??? with debug messages printed
```

Note: this was documented in the [atl06_play.ipynb](https://github.com/weiji14/deepicedrain/blob/master/atl06_play.ipynb) notebook under the [XrViz](https://github.com/intake/xrviz) section.