### PR TITLE
Refresh Github Actions Continuous Integration dependencies

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,11 +1,14 @@
 name: Build DeepIceDrain
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:
-
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.2.0
     - name: Build DeepIceDrain App
       run: docker build --file Dockerfile --tag weiji14/deepicedrain --target app .

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,4 +1,4 @@
-name: Test DeepIceDrain package
+name: Test DeepIceDrain
 
 on:
   push:
@@ -8,14 +8,14 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.os }} - Python ${{ matrix.python_version }}
+    name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1
       fail-fast: false
       matrix:
-        python_version: [3.8]
-        os: [ubuntu-latest]
+        python-version: [3.8]
+        os: [ubuntu-20.04]
 
     steps:
       - name: Checkout current git repository

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout current git repository
-        uses: actions/checkout@v2.1.0
+        uses: actions/checkout@v2.2.0
 
       - name: Setup Miniconda
-        uses: goanpeca/setup-miniconda@v1.4.1
+        uses: goanpeca/setup-miniconda@v1.5.0
         with:
           miniconda-version: py38_4.8.2
           activate-environment: deepicedrain
@@ -33,7 +33,7 @@ jobs:
           use-only-tar-bz2: true
 
       - name: Cache virtual environment
-        uses: actions/cache@v2
+        uses: actions/cache@v2.0.0
         id: cache
         with:
           path: |


### PR DESCRIPTION
General maintenance to keep things up to date and consistent across our Continuous Integration services.

TODO:

- [x] Run Continuous Integration builds and tests on Ubuntu 20.04 Focal Fossa
- [ ] Update third-party Github Actions

Should also set-up dependabot to do the third-party Github Actions update automatically (see https://dependabot.com/github-actions/), once this PR is merged.