### PR TITLE
Downcast data variables to smaller dtype

### DIFF
--- a/atl06_to_atl11.ipynb
+++ b/atl06_to_atl11.ipynb
@@ -267,6 +267,14 @@
     "    # Rename quality_summary variable to avoid name class when merging\n",
     "    ds = ds.rename({\"quality_summary\": f\"quality_summary_{subgroup}\"})\n",
     "\n",
+    "    # Convert variables to correct datatype, except for delta_time\n",
+    "    for variable in list(ds.variables):\n",
+    "        current_dtype = ds[variable].dtype\n",
+    "        desired_dtype = ds[variable].datatype.lower()\n",
+    "        if current_dtype != desired_dtype:\n",
+    "            if variable != \"delta_time\":\n",
+    "                ds[variable] = ds[variable].astype(desired_dtype)\n",
+    "\n",
     "    return ds"
    ]
   },
@@ -371,12 +379,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|█████████▉| 1387/1387 [46:42<00:00,  3.00it/s]   "
+      "100%|██████████| 1387/1387 [1:26:20<00:00,  3.74s/it] \n"
      ]
     }
    ],
    "source": [
-    "# Do all the HDF5 to Zarr conversion! Should take less than an hour to run.\n",
+    "# Do all the HDF5 to Zarr conversion! Should take an hour or two to run\n",
     "# Check conversion progress here, https://stackoverflow.com/a/37901797/6611055\n",
     "futures = [client.compute(store_task) for store_task in stores]\n",
     "for f in tqdm.tqdm(\n",

--- a/atl06_to_atl11.py
+++ b/atl06_to_atl11.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: hydrogen
 #       format_version: '1.3'
-#       jupytext_version: 1.4.2
+#       jupytext_version: 1.5.0
 #   kernelspec:
 #     display_name: deepicedrain
 #     language: python
@@ -162,6 +162,14 @@ def open_ATL11(atl11file: str, group: str) -> xr.Dataset:
     # Rename quality_summary variable to avoid name class when merging
     ds = ds.rename({"quality_summary": f"quality_summary_{subgroup}"})
 
+    # Convert variables to correct datatype, except for delta_time
+    for variable in list(ds.variables):
+        current_dtype = ds[variable].dtype
+        desired_dtype = ds[variable].datatype.lower()
+        if current_dtype != desired_dtype:
+            if variable != "delta_time":
+                ds[variable] = ds[variable].astype(desired_dtype)
+
     return ds
 
 
@@ -229,7 +237,7 @@ for zarrfilepath, atl11files in tqdm.tqdm(iterable=atl11_dict.items()):
     stores.append(store_task)
 
 # %%
-# Do all the HDF5 to Zarr conversion! Should take less than an hour to run.
+# Do all the HDF5 to Zarr conversion! Should take an hour or two to run
 # Check conversion progress here, https://stackoverflow.com/a/37901797/6611055
 futures = [client.compute(store_task) for store_task in stores]
 for f in tqdm.tqdm(


### PR DESCRIPTION
Some variables were loaded into xarray as int64/float64, when they're actually meant to be just int8/int32/float32! Should cast them to the proper size (as specified in the HDF5 metadata) to save on memory space. Will also downcast the ATL11 height related variables to float32 instead of float64, since ATL06 height uses only float32 precision.

List of variables to downcast:
- cycle_number int64 -> int8
- quality_summary float64 -> int8
- ref_pt int64 -> int32
- complex_surface_flag float64 -> int8
- deg_x float64 -> int8
- deg_y float64 -> int8
- poly_exponent_x int64 -> int8
- poly_exponent_y int64 -> int8
- quality_summary float64 -> int8
- ref_pt int64 -> int32

TODO:
- [x] Downcast variables to proper dtype (c6a3abb245a4c6c31a22c1a3ea227e1deeb0b336)
- [ ] DownCast height related variables from float64 to float32.