### PR TITLE
Use intake-geopandas to load polygon data

### DIFF
--- a/atlxi_lake.ipynb
+++ b/atlxi_lake.ipynb
@@ -113,8 +113,8 @@
    "outputs": [],
    "source": [
     "# Read in Antarctic Drainage Basin Boundaries shapefile into a GeoDataFrame\n",
-    "ice_boundaries: gpd.GeoDataFrame = gpd.read_file(\n",
-    "    filename=\"Quantarctica3/Glaciology/MEaSUREs Antarctic Boundaries/IceBoundaries_Antarctica_v2.shp\"\n",
+    "ice_boundaries: gpd.GeoDataFrame = (\n",
+    "    deepicedrain.catalog.measures_antarctic_boundaries.read()\n",
     ")\n",
     "drainage_basins: gpd.GeoDataFrame = ice_boundaries.query(expr=\"TYPE == 'GR'\")"
    ]

--- a/atlxi_lake.ipynb
+++ b/atlxi_lake.ipynb
@@ -922,9 +922,7 @@
    "outputs": [],
    "source": [
     "# Antarctic subglacial lake polygons with EPSG:3031 coordinates\n",
-    "antarctic_lakes: gpd.GeoDataFrame = gpd.read_file(\n",
-    "    filename=\"antarctic_subglacial_lakes_3031.geojson\"\n",
-    ")"
+    "antarctic_lakes: gpd.GeoDataFrame = deepicedrain.catalog.subglacial_lakes.read()"
    ]
   },
   {

--- a/atlxi_lake.py
+++ b/atlxi_lake.py
@@ -347,9 +347,7 @@ df_dhdt: cudf.DataFrame = cudf.read_parquet(
 
 # %%
 # Antarctic subglacial lake polygons with EPSG:3031 coordinates
-antarctic_lakes: gpd.GeoDataFrame = gpd.read_file(
-    filename="antarctic_subglacial_lakes_3031.geojson"
-)
+antarctic_lakes: gpd.GeoDataFrame = deepicedrain.catalog.subglacial_lakes.read()
 
 # %%
 # Choose one draining/filling lake

--- a/atlxi_lake.py
+++ b/atlxi_lake.py
@@ -85,8 +85,8 @@ if not os.path.exists("ATLXI/df_dhdt_antarctica.parquet"):
 
 # %%
 # Read in Antarctic Drainage Basin Boundaries shapefile into a GeoDataFrame
-ice_boundaries: gpd.GeoDataFrame = gpd.read_file(
-    filename="Quantarctica3/Glaciology/MEaSUREs Antarctic Boundaries/IceBoundaries_Antarctica_v2.shp"
+ice_boundaries: gpd.GeoDataFrame = (
+    deepicedrain.catalog.measures_antarctic_boundaries.read()
 )
 drainage_basins: gpd.GeoDataFrame = ice_boundaries.query(expr="TYPE == 'GR'")
 

--- a/deepicedrain/README.md
+++ b/deepicedrain/README.md
@@ -2,10 +2,11 @@
 
 Contents:
 
-- :artificial_satellite: atlas_catalog.yaml - [intake](https://intake.readthedocs.io) data catalog for accessing ICESat-2 ATLAS datasets
+- :artificial_satellite: atlas_catalog.yaml - [intake](https://intake.readthedocs.io) data catalog for accessing ICESat-2 ATLAS datasets and other Antarctic features
   - icesat2atlasdownloader - Download Antarctic ICESat-2 ATLAS products from [NSIDC](https://nsidc.org/data/ICESat-2)
   - icesat2atl06 - Reads in ICESat-2 ATL06 data into an xarray.Dataset
   - icesat2dhdt - Preprocessed ICESat-2 height change over time (dhdt) data in a columnar format
+  - subglacial_lakes - ICESat-2 detected Antarctic subglacial lake polygons as a geopandas.GeoDataFrame
   - test_data - Sample ICESat-2 datasets for testing purposes
 
 - :1234: deltamath.py - Mathematical functions for calculating delta changes of some physical unit

--- a/deepicedrain/README.md
+++ b/deepicedrain/README.md
@@ -6,6 +6,7 @@ Contents:
   - icesat2atlasdownloader - Download Antarctic ICESat-2 ATLAS products from [NSIDC](https://nsidc.org/data/ICESat-2)
   - icesat2atl06 - Reads in ICESat-2 ATL06 data into an xarray.Dataset
   - icesat2dhdt - Preprocessed ICESat-2 height change over time (dhdt) data in a columnar format
+  - measures_antarctic_boundaries - MEaSUREs Antarctic Boundaries from Satellite Radar as a geopandas.GeoDataFrame
   - subglacial_lakes - ICESat-2 detected Antarctic subglacial lake polygons as a geopandas.GeoDataFrame
   - test_data - Sample ICESat-2 datasets for testing purposes
 

--- a/deepicedrain/atlas_catalog.yaml
+++ b/deepicedrain/atlas_catalog.yaml
@@ -161,6 +161,18 @@ sources:
         h_corr:
           c: h_corr_{{cycle}}
           cmap: gist_earth
+  subglacial_lakes:
+    description: 'Antarctic subglacial lake polygons detected from ICESat-2/ATLAS laser altimetry'
+    args:
+      urlpath: antarctic_subglacial_lakes_{{epsg}}.geojson
+    parameters:
+      epsg:
+        description: Coordinate Reference System as an EPSG code
+        type: int
+        default: 3031
+        allowed: [3031, 4326]
+    driver: intake_geopandas.geopandas.GeoJSONSource
+    metadata: {}
   test_data:
     description: 'Sample ICESat-2 datasets for testing purposes'
     args:

--- a/deepicedrain/atlas_catalog.yaml
+++ b/deepicedrain/atlas_catalog.yaml
@@ -161,6 +161,28 @@ sources:
         h_corr:
           c: h_corr_{{cycle}}
           cmap: gist_earth
+  measures_antarctic_boundaries:
+    description: 'MEaSUREs Antarctic Boundaries for IPY 2007-2009 from Satellite Radar, Version 2'
+    args:
+      storage_options:
+        simplecache:
+          cache_storage: Quantarctica3/Glaciology/MEaSUREs Antarctic Boundaries/
+          same_names: true
+      urlpath:
+        - simplecache::http://data.pgc.umn.edu/gis/packages/quantarctica/Quantarctica3/Glaciology/MEaSUREs%20Antarctic%20Boundaries/{{boundary_type}}_Antarctica_v2.dbf
+        - simplecache::http://data.pgc.umn.edu/gis/packages/quantarctica/Quantarctica3/Glaciology/MEaSUREs%20Antarctic%20Boundaries/{{boundary_type}}_Antarctica_v2.prj
+        - simplecache::http://data.pgc.umn.edu/gis/packages/quantarctica/Quantarctica3/Glaciology/MEaSUREs%20Antarctic%20Boundaries/{{boundary_type}}_Antarctica_v2.qix
+        - simplecache::http://data.pgc.umn.edu/gis/packages/quantarctica/Quantarctica3/Glaciology/MEaSUREs%20Antarctic%20Boundaries/{{boundary_type}}_Antarctica_v2.shp
+        - simplecache::http://data.pgc.umn.edu/gis/packages/quantarctica/Quantarctica3/Glaciology/MEaSUREs%20Antarctic%20Boundaries/{{boundary_type}}_Antarctica_v2.shx
+      use_fsspec: true
+    parameters:
+      boundary_type:
+        description: 'Antarctic Boundary type. Either Coastline, GroundingLine or IceBoundaries'
+        type: str
+        default: IceBoundaries
+        allowed: ["Coastline", "GroundingLine", "IceBoundaries"]
+    driver: intake_geopandas.geopandas.ShapefileSource
+    metadata: {}
   subglacial_lakes:
     description: 'Antarctic subglacial lake polygons detected from ICESat-2/ATLAS laser altimetry'
     args:

--- a/deepicedrain/tests/test_deepicedrain.py
+++ b/deepicedrain/tests/test_deepicedrain.py
@@ -16,6 +16,7 @@ def test_deepicedrain_catalog():
         "icesat2atlasdownloader",
         "icesat2atl06",
         "icesat2dhdt",
+        "measures_antarctic_boundaries",
         "subglacial_lakes",
         "test_data",
     ]

--- a/deepicedrain/tests/test_deepicedrain.py
+++ b/deepicedrain/tests/test_deepicedrain.py
@@ -16,6 +16,7 @@ def test_deepicedrain_catalog():
         "icesat2atlasdownloader",
         "icesat2atl06",
         "icesat2dhdt",
+        "subglacial_lakes",
         "test_data",
     ]
     assert list(catalog) == catalog_entries

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,16 +1,17 @@
 [[package]]
 name = "aiohttp"
-version = "3.6.2"
+version = "3.7.2"
 description = "Async http client/server framework (asyncio)"
 category = "main"
 optional = false
-python-versions = ">=3.5.3"
+python-versions = ">=3.6"
 
 [package.dependencies]
 async-timeout = ">=3.0,<4.0"
 attrs = ">=17.3.0"
 chardet = ">=2.0,<4.0"
-multidict = ">=4.5,<5.0"
+multidict = ">=4.5,<7.0"
+typing-extensions = ">=3.6.5"
 yarl = ">=1.0,<2.0"
 
 [package.extras]
@@ -85,7 +86,7 @@ python-versions = ">=3.5.3"
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -750,7 +751,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -781,16 +782,25 @@ server = ["tornado", "python-snappy"]
 
 [[package]]
 name = "intake-geopandas"
-version = "0.2.3"
+version = "0.2.3+40.ge08c89b"
 description = "Geopandas plugin for Intake"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 geopandas = "*"
 intake = "*"
-pytest = "*"
+
+[package.extras]
+arrow = ["pyarrow"]
+regionmask = ["regionmask"]
+
+[package.source]
+type = "git"
+url = "https://github.com/intake/intake_geopandas.git"
+reference = "e08c89bdd95216e9ff3f5bb6f8547799e7e7a463"
+resolved_reference = "e08c89bdd95216e9ff3f5bb6f8547799e7e7a463"
 
 [[package]]
 name = "intake-parquet"
@@ -1509,7 +1519,7 @@ python-versions = ">=3.5"
 name = "pluggy"
 version = "0.13.1"
 description = "plugin and hook calling mechanisms for python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -1584,7 +1594,7 @@ python-versions = "*"
 name = "py"
 version = "1.9.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -1731,7 +1741,7 @@ python-versions = ">= 2.7"
 name = "pytest"
 version = "6.1.2"
 description = "pytest: simple powerful testing with Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
 
@@ -2037,7 +2047,7 @@ twisted = ["twisted"]
 name = "toml"
 version = "0.10.1"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -2219,22 +2229,43 @@ cuda = ["cupy-cuda102", "dask-cuda"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "72e7992e72afb48b3f17851ececa9cf5d965ff3a597460f7fd432acd9a22df39"
+content-hash = "311495e2d1b69c2ce9594daf94f3c129a714201121134a0aaf56b26320c0841c"
 
 [metadata.files]
 aiohttp = [
-    {file = "aiohttp-3.6.2-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:1e984191d1ec186881ffaed4581092ba04f7c61582a177b187d3a2f07ed9719e"},
-    {file = "aiohttp-3.6.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:50aaad128e6ac62e7bf7bd1f0c0a24bc968a0c0590a726d5a955af193544bcec"},
-    {file = "aiohttp-3.6.2-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:65f31b622af739a802ca6fd1a3076fd0ae523f8485c52924a89561ba10c49b48"},
-    {file = "aiohttp-3.6.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ae55bac364c405caa23a4f2d6cfecc6a0daada500274ffca4a9230e7129eac59"},
-    {file = "aiohttp-3.6.2-cp36-cp36m-win32.whl", hash = "sha256:344c780466b73095a72c616fac5ea9c4665add7fc129f285fbdbca3cccf4612a"},
-    {file = "aiohttp-3.6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:4c6efd824d44ae697814a2a85604d8e992b875462c6655da161ff18fd4f29f17"},
-    {file = "aiohttp-3.6.2-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:2f4d1a4fdce595c947162333353d4a44952a724fba9ca3205a3df99a33d1307a"},
-    {file = "aiohttp-3.6.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:6206a135d072f88da3e71cc501c59d5abffa9d0bb43269a6dcd28d66bfafdbdd"},
-    {file = "aiohttp-3.6.2-cp37-cp37m-win32.whl", hash = "sha256:b778ce0c909a2653741cb4b1ac7015b5c130ab9c897611df43ae6a58523cb965"},
-    {file = "aiohttp-3.6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:32e5f3b7e511aa850829fbe5aa32eb455e5534eaa4b1ce93231d00e2f76e5654"},
-    {file = "aiohttp-3.6.2-py3-none-any.whl", hash = "sha256:460bd4237d2dbecc3b5ed57e122992f60188afe46e7319116da5eb8a9dfedba4"},
-    {file = "aiohttp-3.6.2.tar.gz", hash = "sha256:259ab809ff0727d0e834ac5e8a283dc5e3e0ecc30c4d80b3cd17a4139ce1f326"},
+    {file = "aiohttp-3.7.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:0989ff15834a4503056d103077ec3652f9ea5699835e1ceaee46b91cf59830bf"},
+    {file = "aiohttp-3.7.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:8fbeeb2296bb9fe16071a674eadade7391be785ae0049610e64b60ead6abcdd7"},
+    {file = "aiohttp-3.7.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:48104c883099c0e614c5c38f98c1d174a2c68f52f58b2a6e5a07b59df78262ab"},
+    {file = "aiohttp-3.7.2-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:c9a415f4f2764ab6c7d63ee6b86f02a46b4df9bc11b0de7ffef206908b7bf0b4"},
+    {file = "aiohttp-3.7.2-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:7e26712871ebaf55497a60f55483dc5e74326d1fb0bfceab86ebaeaa3a266733"},
+    {file = "aiohttp-3.7.2-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:8319a55de469d5af3517dfe1f6a77f248f6668c5a552396635ef900f058882ef"},
+    {file = "aiohttp-3.7.2-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:2aea79734ac5ceeac1ec22b4af4efb4efd6a5ca3d73d77ec74ed782cf318f238"},
+    {file = "aiohttp-3.7.2-cp36-cp36m-win_amd64.whl", hash = "sha256:be9fa3fe94fc95e9bf84e84117a577c892906dd3cb0a95a7ae21e12a84777567"},
+    {file = "aiohttp-3.7.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04dcbf6af1868048a9b4754b1684c669252aa2419aa67266efbcaaead42ced7"},
+    {file = "aiohttp-3.7.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2e886611b100c8c93b753b457e645c5e4b8008ec443434d2a480e5a2bb3e6514"},
+    {file = "aiohttp-3.7.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cdbb65c361ff790c424365a83a496fc8dd1983689a5fb7c6852a9a3ff1710c61"},
+    {file = "aiohttp-3.7.2-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:8a8addd41320637c1445fea0bae1fd9fe4888acc2cd79217ee33e5d1c83cfe01"},
+    {file = "aiohttp-3.7.2-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:b822bf7b764283b5015e3c49b7bb93f37fc03545f4abe26383771c6b1c813436"},
+    {file = "aiohttp-3.7.2-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:ad5c3559e3cd64f746df43fa498038c91aa14f5d7615941ea5b106e435f3b892"},
+    {file = "aiohttp-3.7.2-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:835bd35e14e4f36414e47c195e6645449a0a1c3fd5eeae4b7f22cb4c5e4f503a"},
+    {file = "aiohttp-3.7.2-cp37-cp37m-win_amd64.whl", hash = "sha256:11e087c316e933f1f52f3d4a09ce13f15ad966fc43df47f44ca4e8067b6a2e0d"},
+    {file = "aiohttp-3.7.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:f8c583c31c6e790dc003d9d574e3ed2c5b337947722965096c4d684e4f183570"},
+    {file = "aiohttp-3.7.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b84cef790cb93cec82a468b7d2447bf16e3056d2237b652e80f57d653b61da88"},
+    {file = "aiohttp-3.7.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:4afd8002d9238e5e93acf1a8baa38b3ddf1f7f0ebef174374131ff0c6c2d7973"},
+    {file = "aiohttp-3.7.2-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:a1f1cc11c9856bfa7f1ca55002c39070bde2a97ce48ef631468e99e2ac8e3fe6"},
+    {file = "aiohttp-3.7.2-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:7f1aeb72f14b9254296cdefa029c00d3c4550a26e1059084f2ee10d22086c2d0"},
+    {file = "aiohttp-3.7.2-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:67f8564c534d75c1d613186939cee45a124d7d37e7aece83b17d18af665b0d7a"},
+    {file = "aiohttp-3.7.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:184ead67248274f0e20b0cd6bb5f25209b2fad56e5373101cc0137c32c825c87"},
+    {file = "aiohttp-3.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:6e0d1231a626d07b23f6fe904caa44efb249da4222d8a16ab039fb2348722292"},
+    {file = "aiohttp-3.7.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:476b1f8216e59a3c2ffb71b8d7e1da60304da19f6000d422bacc371abb0fc43d"},
+    {file = "aiohttp-3.7.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:89c1aa729953b5ac6ca3c82dcbd83e7cdecfa5cf9792c78c154a642e6e29303d"},
+    {file = "aiohttp-3.7.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c53f1d2bd48f5f407b534732f5b3c6b800a58e70b53808637848d8a9ee127fe7"},
+    {file = "aiohttp-3.7.2-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:06efdb01ab71ec20786b592d510d1d354fbe0b2e4449ee47067b9ca65d45a006"},
+    {file = "aiohttp-3.7.2-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:027be45c4b37e21be81d07ae5242361d73eebad1562c033f80032f955f34df82"},
+    {file = "aiohttp-3.7.2-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:1c36b7ef47cfbc150314c2204cd73613d96d6d0982d41c7679b7cdcf43c0e979"},
+    {file = "aiohttp-3.7.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c588a0f824dc7158be9eec1ff465d1c868ad69a4dc518cd098cc11e4f7da09d9"},
+    {file = "aiohttp-3.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:547b196a7177511da4f475fc81d0bb88a51a8d535c7444bbf2338b6dc82cb996"},
+    {file = "aiohttp-3.7.2.tar.gz", hash = "sha256:c6da1af59841e6d43255d386a2c4bfb59c0a3b262bdb24325cc969d211be6070"},
 ]
 apipkg = [
     {file = "apipkg-1.5-py2.py3-none-any.whl", hash = "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"},
@@ -2612,10 +2643,7 @@ intake = [
     {file = "intake-0.6.0-py3-none-any.whl", hash = "sha256:32a6d77965f3b89a12894c29e8c7516391a0be4c42902af52f12747186920bcc"},
     {file = "intake-0.6.0.tar.gz", hash = "sha256:0c284abeb74927a7366dcab6cefc010c4d050365b8af61c37326a2473a490a4e"},
 ]
-intake-geopandas = [
-    {file = "intake_geopandas-0.2.3-py3-none-any.whl", hash = "sha256:a642af8103c186112596cd25764e54d0502b673f2b263371ccb6ea81a8be3e7d"},
-    {file = "intake_geopandas-0.2.3.tar.gz", hash = "sha256:7a0303b758a4d4323b8c905274d98608da0373c6d559e48d4f09054851608172"},
-]
+intake-geopandas = []
 intake-parquet = [
     {file = "intake-parquet-0.2.3.tar.gz", hash = "sha256:353078f8b3358abdf0b1fa959fb8bd7f40466c8d04c474f51015b13822b9b8e3"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -85,7 +85,7 @@ python-versions = ">=3.5.3"
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -750,7 +750,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -778,6 +778,19 @@ complete = ["bokeh (<2.0)", "dask", "hvplot", "msgpack-numpy", "panel (>=0.7.0)"
 dataframe = ["dask", "msgpack-numpy", "pyarrow"]
 plot = ["hvplot", "panel (>=0.7.0)", "bokeh (<2.0)"]
 server = ["tornado", "python-snappy"]
+
+[[package]]
+name = "intake-geopandas"
+version = "0.2.3"
+description = "Geopandas plugin for Intake"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+geopandas = "*"
+intake = "*"
+pytest = "*"
 
 [[package]]
 name = "intake-parquet"
@@ -1496,7 +1509,7 @@ python-versions = ">=3.5"
 name = "pluggy"
 version = "0.13.1"
 description = "plugin and hook calling mechanisms for python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -1571,7 +1584,7 @@ python-versions = "*"
 name = "py"
 version = "1.9.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -1718,7 +1731,7 @@ python-versions = ">= 2.7"
 name = "pytest"
 version = "6.1.2"
 description = "pytest: simple powerful testing with Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 
@@ -2024,7 +2037,7 @@ twisted = ["twisted"]
 name = "toml"
 version = "0.10.1"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -2206,7 +2219,7 @@ cuda = ["cupy-cuda102", "dask-cuda"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "37a666c41eea0fac63fc2e905fd2c7e289a7c0e549400cbd649544b9a20ffa25"
+content-hash = "72e7992e72afb48b3f17851ececa9cf5d965ff3a597460f7fd432acd9a22df39"
 
 [metadata.files]
 aiohttp = [
@@ -2598,6 +2611,10 @@ iniconfig = [
 intake = [
     {file = "intake-0.6.0-py3-none-any.whl", hash = "sha256:32a6d77965f3b89a12894c29e8c7516391a0be4c42902af52f12747186920bcc"},
     {file = "intake-0.6.0.tar.gz", hash = "sha256:0c284abeb74927a7366dcab6cefc010c4d050365b8af61c37326a2473a490a4e"},
+]
+intake-geopandas = [
+    {file = "intake_geopandas-0.2.3-py3-none-any.whl", hash = "sha256:a642af8103c186112596cd25764e54d0502b673f2b263371ccb6ea81a8be3e7d"},
+    {file = "intake_geopandas-0.2.3.tar.gz", hash = "sha256:7a0303b758a4d4323b8c905274d98608da0373c6d559e48d4f09054851608172"},
 ]
 intake-parquet = [
     {file = "intake-parquet-0.2.3.tar.gz", hash = "sha256:353078f8b3358abdf0b1fa959fb8bd7f40466c8d04c474f51015b13822b9b8e3"},
@@ -3001,6 +3018,11 @@ pandas = [
     {file = "pandas-1.1.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:df43ea0e9fd9f9672b0de9cac26d01255ad50481994bf3cb4687c21eec2d7bbc"},
     {file = "pandas-1.1.3-cp38-cp38-win32.whl", hash = "sha256:a605054fbca71ed1d08bb2aef6f73c84a579bbac956bfe8f9718d5e84cb41248"},
     {file = "pandas-1.1.3-cp38-cp38-win_amd64.whl", hash = "sha256:84a4ffe668df357e31f98c829536e3a7142c3036c82f996e639f644c5d32eda1"},
+    {file = "pandas-1.1.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:147162568b1242355290341baf281926cfac66ada07e634f3fc521ac967e4653"},
+    {file = "pandas-1.1.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2999adc6736f8cb4c69d65a6e2b25a11bcb395da5b048342b8e4d6fe055e57ae"},
+    {file = "pandas-1.1.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f4cb8252ae71f093f4a6b847adf0bc9330f109c48f08363c2071f189f1c89c87"},
+    {file = "pandas-1.1.3-cp39-cp39-win32.whl", hash = "sha256:b026e913d88fad3a74eea8ed5a5f98e8823080ea02f8d9bb0ec19e92552daad6"},
+    {file = "pandas-1.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:11c284769f41e95f7d16a327eb555989c5f29418aad075fa80c97ef3aa8fb885"},
     {file = "pandas-1.1.3.tar.gz", hash = "sha256:babbeda2f83b0686c9ad38d93b10516e68cdcd5771007eb80a763e98aaf44613"},
 ]
 pandocfilters = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ geopandas = "^0.8.1"
 geoviews = "^1.8.1"
 h5netcdf = "^0.8.1"
 intake = {extras = ["dataframe", "server"], version = "^0.6.0"}
+intake-geopandas = "^0.2.3"
 intake-parquet = "^0.2.3"
 intake-xarray = "^0.4.0"
 jupyterlab = "^2.2.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ geopandas = "^0.8.1"
 geoviews = "^1.8.1"
 h5netcdf = "^0.8.1"
 intake = {extras = ["dataframe", "server"], version = "^0.6.0"}
-intake-geopandas = "^0.2.3"
+intake-geopandas = {git = "https://github.com/intake/intake_geopandas.git", rev = "e08c89bdd95216e9ff3f5bb6f8547799e7e7a463"}
 intake-parquet = "^0.2.3"
 intake-xarray = "^0.4.0"
 jupyterlab = "^2.2.8"


### PR DESCRIPTION
Make it easier to open geographic boundaries (polygon outlines) by utilizing [intake-geopandas](https://github.com/intake/intake_geopandas). Will put it into `atlas_catalog.yaml` for now (rather than having a separate yaml file).

![Antarctic Boundaries v02.shp overview. The shapefile includes the coastline, the grounding line, an ice shelf mask (striped), as well as IMBIE and refined basins. Also provided is a regional separation in East Antarctica (red lines), West Antarctica (green lines), and the Antarctic Peninsula (dark blue lines)](https://nsidc.org/sites/nsidc.org/files/images/data/measures/0709v2/Screen_Shot_2017-03-02_at_11_06_21_AM.png)

TODO:
- [x] Add intake-geopandas (756dc5421448b8f240918b72e5298710fa181237)
- [x] Place antarctic_lakes_3031/4326.geojson into intake catalog (274ddbf262b2f4607f092ffc8bd76f4f4f7047d8)
- [x] Update intake-geopandas from v0.2.3 to newer version (https://github.com/intake/intake_geopandas/commit/e08c89bdd95216e9ff3f5bb6f8547799e7e7a463) as it comes with better shapefile cache management (baa7ffa1227abb7e65158512f38a04840d60a32a)
- [x] Place Antarctic Boundaries (Coastline, GroundingLine, **IceBoundaries**) from Quantarctica/PGC into intake catalog (292edfc90479df27f3bf400c6f3a12017065480f)

References:
- Mouginot, J., Scheuchl, B., & Rignot, E. (2017). MEaSURES Antarctic Boundaries for IPY 2007-2009 from Satellite Radar, Version 2 [Data set]. NASA National Snow and Ice Data Center DAAC. https://doi.org/10.5067/AXE4121732AD