### PR TITLE
:whale: Migrate Dockerfile from conda to mamba and link to Pangeo BinderHub

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2.2.0

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     defaults:
       run:
         shell: bash -l {0}
@@ -26,34 +26,20 @@ jobs:
       - name: Checkout current git repository
         uses: actions/checkout@v2.2.0
 
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.0.0
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v2.1.1
         with:
-          miniconda-version: py38_4.8.3
           activate-environment: deepicedrain
-          python-version: ${{ matrix.python-version }}
           channels: conda-forge
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          mamba-version: "*"
+          use-mamba: true
+          environment-file: environment-linux-64.lock
           show-channel-urls: true
-          auto-activate-base: false
-      #     use-only-tar-bz2: true
-      #
-      # - name: Cache virtual environment
-      #   uses: actions/cache@v2.0.0
-      #   id: cache
-      #   with:
-      #     path: |
-      #       /usr/share/miniconda3/envs/deepicedrain
-      #     key: cache-venv-${{ github.ref }}-${{ hashFiles('**/environment.yml') }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('**/deepicedrain/*.py') }}
-      #     restore-keys: |
-      #       cache-venv-refs/heads/main-${{ hashFiles('**/environment.yml') }}-
-
-      - name: Install conda dependencies
-        run: conda env update -n deepicedrain -f environment.yml
-        # if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install Poetry python dependencies
         run: poetry install --no-root
-        # if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install deepicedrain package
         run: poetry install
@@ -68,8 +54,8 @@ jobs:
 
       - name: Display virtualenv and installed package information
         run: |
-          conda info
-          conda list
+          mamba info
+          mamba list
           poetry env info
           poetry show
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:focal-scm@sha256:21530e8173a4d4e75c9029ee14344327eb873be0f21a97deea1ea03bebccc599 AS base
+FROM buildpack-deps:jammy-scm@sha256:69a05e44c60e1a1002f2d9699f0418c640a3eadc89dcdfc9dbe87db7e7d87887 AS base
 LABEL maintainer "https://github.com/weiji14"
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
@@ -15,22 +15,18 @@ RUN adduser --disabled-password \
     --uid ${NB_UID} \
     ${NB_USER}
 
-# Setup conda
-ENV CONDA_DIR ${HOME}/.conda
-ENV NB_PYTHON_PREFIX ${CONDA_DIR}
-ENV MINICONDA_VERSION 4.10.3
+# Setup mamba
+ENV MAMBA_DIR ${HOME}/.mamba
+ENV NB_PYTHON_PREFIX ${MAMBA_DIR}
+ENV MAMBAFORGE_VERSION 4.14.0-0
 
 RUN cd /tmp && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    echo "14da4a9a44b337f7ccb8363537f65b9c *Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
-    /bin/bash Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
-    rm Miniconda3-py38_${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    $CONDA_DIR/bin/conda config --system --prepend channels conda-forge && \
-    $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
-    $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
-    $CONDA_DIR/bin/conda config --system --set pip_interop_enabled true && \
-    $CONDA_DIR/bin/conda clean --all --quiet --yes && \
-    $CONDA_DIR/bin/conda init --verbose
+    wget --quiet https://github.com/conda-forge/miniforge/releases/download/${MAMBAFORGE_VERSION}/Mambaforge-${MAMBAFORGE_VERSION}-Linux-x86_64.sh && \
+    echo "d47b78b593e3cf5513bafbfa6a51eafcd9f0e164c41c79c790061bb583c82859 *Mambaforge-${MAMBAFORGE_VERSION}-Linux-x86_64.sh" | sha256sum -c - && \
+    /bin/bash Mambaforge-${MAMBAFORGE_VERSION}-Linux-x86_64.sh -f -b -p $MAMBA_DIR && \
+    rm Mambaforge-${MAMBAFORGE_VERSION}-Linux-x86_64.sh && \
+    $MAMBA_DIR/bin/mamba clean --all --quiet --yes && \
+    $MAMBA_DIR/bin/mamba init --verbose
 
 # Setup $HOME directory with correct permissions
 USER root
@@ -38,27 +34,28 @@ RUN chown -R ${NB_UID} ${HOME}
 USER ${NB_USER}
 WORKDIR ${HOME}
 
-# Change to interactive bash shell, so that `conda activate` works
+# Change to interactive bash shell, so that `mamba activate` works
 SHELL ["/bin/bash", "-ic"]
 
-# Install dependencies in environment.yml file using conda
+# Install dependencies in environment-linux-64.lock file using mamba
 COPY environment.yml ${HOME}
-RUN conda env create -n deepicedrain -f environment.yml && \
-    conda clean --all --yes && \
-    conda info && \
-    conda list -n deepicedrain
+COPY environment-linux-64.lock ${HOME}
+RUN mamba create --name deepicedrain --file environment-linux-64.lock && \
+    mamba clean --all --yes && \
+    mamba info && \
+    mamba list -n deepicedrain
 
 # Install dependencies in poetry.lock using poetry
 COPY pyproject.toml ${HOME}/
 COPY poetry.lock ${HOME}/
-RUN conda activate deepicedrain && \
+RUN mamba activate deepicedrain && \
     poetry install && \
     rm --recursive ${HOME}/.cache/pip && \
     poetry env info && \
     poetry show
 
 # Setup DeepBedMap virtual environment properly
-RUN conda activate deepicedrain && \
+RUN mamba activate deepicedrain && \
     python -m ipykernel install --user --name deepicedrain && \
     jupyter kernelspec list --json
 
@@ -70,7 +67,7 @@ FROM base AS app
 
 # Run Jupyter Lab via poetry in conda environment
 EXPOSE 8888
-RUN echo -e '#!/bin/bash -i\nset -e\nconda activate deepicedrain\npoetry run "$@"' > .entrypoint.sh && \
+RUN echo -e '#!/bin/bash -i\nset -e\nmamba activate deepicedrain\npoetry run "$@"' > .entrypoint.sh && \
     chmod +x .entrypoint.sh
 ENTRYPOINT ["./.entrypoint.sh"]
 CMD ["jupyter", "lab", "--ip", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ on a sample ATL11 dataset between ICESat's Cycle 3 and Cycle 4.
 To just try out the scripts, download the `environment.yml` file from the repository and run the commands below:
 
     cd deepicedrain
-    conda env create --name deepicedrain --file environment.yml
+    mamba env create --name deepicedrain --file environment.yml
     pip install git+https://github.com/weiji14/deepicedrain.git
 
 ### Intermediate

--- a/README.md
+++ b/README.md
@@ -27,9 +27,17 @@ in Antarctica using remote sensing and machine learning.
 
 ## Quickstart
 
-Launch in [Pangeo Binder](https://pangeo-binder.readthedocs.io) (Interactive jupyter lab environment in the cloud).
+Launch in [Binder](https://mybinder.readthedocs.io) (Interactive jupyter lab environment in the cloud).
 
-[![Binder](https://binder.pangeo.io/badge_logo.svg)](https://binder.pangeo.io/v2/gh/weiji14/deepicedrain/main)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/weiji14/deepicedrain/main)
+
+Alternative [Pangeo BinderHub](https://pangeo-binder.readthedocs.io) link.
+Requires a GitHub account and you'll have to install your own computing environment,
+but it runs on AWS uswest2 which allows for
+[cloud access to ICESat-2](https://nsidc.org/data/user-resources/data-announcements/data-set-updates-new-earthdata-cloud-access-option-icesat-2-and-icesat-data-sets)!
+
+[![Pangeo BinderHub](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://hub.aws-uswest2-binder.pangeo.io/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fweiji14%2Fdeepicedrain&urlpath=lab%2Ftree%2Fdeepicedrain%2F&branch=main)
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -74,15 +74,17 @@ To help out with development, start by cloning this [repo-url](/../../)
 
     git clone <repo-url>
 
-Then I recommend [using conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) to install the non-python binaries.
-The conda virtual environment will also be created with Python and [poetry](https://github.com/python-poetry/poetry) installed.
+Then I recommend [using mamba](https://mamba.readthedocs.io/en/latest/installation.html)
+to install the non-python binaries.
+A virtual environment will also be created with Python and
+[poetry](https://github.com/python-poetry/poetry) installed.
 
     cd deepicedrain
-    conda env create -f environment.yml
+    mamba env create --file environment.yml
 
-Activate the conda environment first.
+Activate the virtual environment first.
 
-    conda activate deepicedrain
+    mamba activate deepicedrain
 
 Then install the python libraries listed in the `pyproject.toml`/`poetry.lock` file.
 
@@ -94,20 +96,20 @@ Finally, double-check that the libraries have been installed.
 
 ### Advanced
 
-This is for those who want full reproducibility of the conda environment,
+This is for those who want full reproducibility of the virtual environment,
 and more computing power by using Graphical Processing Units (GPU).
 
-Making an explicit conda-lock file
-(only needed if creating a new conda environment/refreshing an existing one).
+Making an explicit [conda-lock](https://github.com/conda-incubator/conda-lock) file
+(only needed if creating a new virtual environment/refreshing an existing one).
 
-    conda env create -f environment.yml
-    conda list --explicit > environment-linux-64.lock
+    mamba env create -f environment.yml
+    mamba list --explicit > environment-linux-64.lock
 
 Creating/Installing a virtual environment from a conda lock file.
 See also https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#building-identical-conda-environments.
 
-    conda create --name deepicedrain --file environment-linux-64.lock
-    conda install --name deepicedrain --file environment-linux-64.lock
+    mamba create --name deepicedrain --file environment-linux-64.lock
+    mamba install --name deepicedrain --file environment-linux-64.lock
 
 If you have a [CUDA](https://en.wikipedia.org/wiki/CUDA)-capable GPU,
 you can also install the optional "cuda" packages to accelerate some calculations.
@@ -117,8 +119,8 @@ you can also install the optional "cuda" packages to accelerate some calculation
 
 ## Running jupyter lab
 
-    conda activate deepicedrain
-    python -m ipykernel install --user --name deepicedrain  # to install conda env properly
+    mamba activate deepicedrain
+    python -m ipykernel install --user --name deepicedrain  # to install virtual env properly
     jupyter kernelspec list --json                          # see if kernel is installed
     jupyter lab &
 


### PR DESCRIPTION
Quality of code improvements to make the Pangeo Binder link work again! Modernize the Dockerfile to use mamba instead of conda, and pointing the Pangeo BinderHub button to the new aws-uswest2 instance ([where ICESat-2 data is now hosted](https://nsidc.org/data/user-resources/data-announcements/data-set-updates-new-earthdata-cloud-access-option-icesat-2-and-icesat-data-sets))!

[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://hub.aws-uswest2-binder.pangeo.io/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fweiji14%2Fdeepicedrain&urlpath=lab%2Ftree%2Fdeepicedrain%2F&branch=pangeo-binder%2Faws-uswest2)

Note to self: The Pangeo BinderHub does not persist data after logging out and logging in again, may need to improve user accessibility after some more experimentation.

References:
- https://jupyterhub.github.io/nbgitpuller/link.html
- https://github.com/pangeo-data/pangeo-binder